### PR TITLE
Fix some minification errors related to zero value replacements

### DIFF
--- a/lib/cssminify/cssmin.rb
+++ b/lib/cssminify/cssmin.rb
@@ -180,9 +180,20 @@ module CssCompressor
     #
     # Replace 0(px,em,%) with 0
     #
-    css = css.gsub(/(^|[^0-9])(?:0?\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)/i) { $1.to_s + '0' }
-    
-    #
+    oldCss = '';
+    while oldCss != css do
+      oldCss = css
+      css = css.gsub(/(?i)(^|: ?)((?:[0-9a-z\-\.]+ )*?)?(?:0?\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)/i) { "#{$1.to_s}#{$2.to_s}0" }
+    end
+
+    oldCss = '';
+    while oldCss != css do
+      oldCss = css
+      css = css.gsub(/(?i)\( ?((?:[0-9a-z\-\.]+[ ,])*)?(?:0?\.)?0(?:px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz)/i) { "(#{$1.to_s}0" }
+    end
+
+    css = css.gsub(/([0-9])\.0(px|em|%|in|cm|mm|pc|pt|ex|deg|g?rad|m?s|k?hz| |;)/i) {"#{$1.to_s}#{$2.to_s}"}
+
     # Replace 0 0 0 0; with 0
     #
     css = css.gsub(/:0 0 0 0(;|\})/) { ':0' + $1.to_s }

--- a/spec/cssminify_spec.rb
+++ b/spec/cssminify_spec.rb
@@ -128,7 +128,53 @@ describe "CSSminify" do
       EOS
       CSSminify.compress(source).should eq('a{margin:0;background-position:0 0;padding:0}')
     end
-  
+
+    it "simplifies zero values preserving unit when necessary" do
+      source = <<-EOS
+        @-webkit-keyframes anim {
+          0% {
+            left: 0;
+          }
+          100% {
+            left: -100%;
+          }
+        }
+        @-moz-keyframes anim {
+          0% {
+            left: 0;
+          }
+          100% {
+            left: -100%;
+          }
+        }
+        @-ms-keyframes anim {
+          0% {
+            left: 0;
+          }
+          100% {
+            left: -100%;
+          }
+        }
+        @-o-keyframes anim {
+          0% {
+            left: 0;
+          }
+          100% {
+            left: -100%;
+          }
+        }
+        @keyframes anim {
+          0% {
+            left: 0;
+          }
+          100% {
+            left: -100%;
+          }
+        }
+      EOS
+      CSSminify.compress(source).should eq('@-webkit-keyframes anim{0%{left:0}100%{left:-100%}}@-moz-keyframes anim{0%{left:0}100%{left:-100%}}@-ms-keyframes anim{0%{left:0}100%{left:-100%}}@-o-keyframes anim{0%{left:0}100%{left:-100%}}@keyframes anim{0%{left:0}100%{left:-100%}}')
+    end
+
     it "removes leading zeros from floats" do
       source = <<-EOS
         .classname {
@@ -137,7 +183,25 @@ describe "CSSminify" do
       EOS
       CSSminify.compress(source).should eq('.classname{margin:.6px .333pt 1.2em 8.8cm}')
     end
-  
+
+    it "removes leading zeros from groups" do
+      source = <<-EOS
+        a {
+          margin: 0px 0pt 0em 0%;
+          _padding-top: 0ex;
+          background-position: 0 0;
+          padding: 0in 0cm 0mm 0pc;
+          transition: opacity .0s;
+          transition-delay: 0.0ms;
+          transform: rotate3d(0grad, 0rad, 0deg);
+          pitch: 0khz;
+          pitch:
+        0hz /* intentionally on next line */;
+        }
+      EOS
+      CSSminify.compress(source).should eq('a{margin:0;_padding-top:0;background-position:0 0;padding:0;transition:opacity 0;transition-delay:0;transform:rotate3d(0,0,0);pitch:0;pitch:0}')
+    end
+
     it "simplifies color values but preserves filter properties, RGBa values and ID strings" do
       source = <<-EOS
         .color-me {

--- a/spec/sample.css
+++ b/spec/sample.css
@@ -36,6 +36,47 @@ a {
     padding: 0in 0cm 0mm 0pc
 }
 
+@-webkit-keyframes marquee {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: -100%;
+  }
+}
+@-moz-keyframes marquee {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: -100%;
+  }
+}
+@-ms-keyframes marquee {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: -100%;
+  }
+}
+@-o-keyframes marquee {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: -100%;
+  }
+}
+@keyframes marquee {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: -100%;
+  }
+}
+
 .classname {
     margin: 0.6px 0.333pt 1.2em 8.8cm;
 }

--- a/spec/tests/issue221.css
+++ b/spec/tests/issue221.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'Quicksand';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Quicksand Regular'), local('Quicksand-Regular'), url(https://fonts.gstatic.com/s/quicksand/v5/sKd0EMYPAh5PYCRKSryvW5Bw1xU1rKptJj_0jans920.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/spec/tests/issue221.css.min
+++ b/spec/tests/issue221.css.min
@@ -1,0 +1,1 @@
+@font-face{font-family:'Quicksand';font-style:normal;font-weight:400;src:local('Quicksand Regular'),local('Quicksand-Regular'),url(https://fonts.gstatic.com/s/quicksand/v5/sKd0EMYPAh5PYCRKSryvW5Bw1xU1rKptJj_0jans920.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02C6,U+02DA,U+02DC,U+2000-206F,U+2074,U+20AC,U+2212,U+2215,U+E0FF,U+EFFD,U+F000}

--- a/spec/tests/issue222.css
+++ b/spec/tests/issue222.css
@@ -1,0 +1,3 @@
+@media \0screen {
+  body { background: red; }
+}

--- a/spec/tests/issue222.css.min
+++ b/spec/tests/issue222.css.min
@@ -1,0 +1,1 @@
+@media \0screen{body{background:red}}

--- a/spec/tests/keyframe.css
+++ b/spec/tests/keyframe.css
@@ -1,0 +1,4 @@
+@keyframe anim {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}

--- a/spec/tests/keyframe.css.min
+++ b/spec/tests/keyframe.css.min
@@ -1,0 +1,1 @@
+@keyframe anim{0%{opacity:0}100%{opacity:1}}


### PR DESCRIPTION
Taking the following CSS
@keyframe anim {
  0% { opacity: 0; }
  100% { opacity: 1; }
}
The output will be incorrectly rewritten to:
@keyframe anim {
  0 { opacity: 0; }
  100% { opacity: 1; }
}

This fix was introduced to YUI in pull request #231. I simply applied it to this port

For more information please visit: https://github.com/yui/yuicompressor/pull/231#issue-124952655
